### PR TITLE
Catch exceptions from CSS Parse and emit error for gulp to handle.

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,13 @@ module.exports = function(options) {
     var filename = path.relative(file.cwd, file.path);
     var extFilename = filename.replace('.css', '.responsive.css');
     var source = file.contents.toString('utf8');
-    var cssJson = parseCss(source);
+    var cssJson;
+    try {
+      cssJson = parseCss(source);
+    } catch(e) {
+      this.emit('error', new PluginError(PLUGIN_NAME, e.message));
+      return cb();
+    }
     var strStyles = [];
     var strMediaStyles = [];
     var processedCSS = {};


### PR DESCRIPTION
Noticed that the gulp process exited whenever there was an error with parsing the css.  This allows gulp to handle it without interrupting the process.
