### PR TITLE
Node v4 Buffer does not accept objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,8 +149,6 @@ module.exports = function(options) {
     processedCSS.media.blank = [];
     processedCSS.keyframes = [];
 
-    file.contents = new Buffer(cssJson);
-
     // For every rule in the stylesheet...
     cssJson.stylesheet.rules.forEach(function(rule) {
 


### PR DESCRIPTION
Addresses https://github.com/konitter/gulp-combine-media-queries/issues/19 where this module does not work with node v4.

`cssJson` is an object, and therefore cannot be turned into a Buffer in v4.
