### PR TITLE
Buffer 'must start with number, …' error

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ module.exports = function(options) {
     processedCSS.media.blank = [];
     processedCSS.keyframes = [];
 
-    file.contents = new Buffer(cssJson);
+    file.contents = new Buffer( JSON.stringify(cssJson) );
 
     // For every rule in the stylesheet...
     cssJson.stylesheet.rules.forEach(function(rule) {


### PR DESCRIPTION
As the way this problem has been fixed in webpack-stats-plugin (https://github.com/FormidableLabs/webpack-stats-plugin/commit/07bfbb2695417d9ef3135cdc8f92857fc1a076d8), I add a JSON.stringify around the obect.
This fix resolve my problem.
Regards
